### PR TITLE
Fix: Make qml module targets publicly visible

### DIFF
--- a/cmake/CxxQt.cmake
+++ b/cmake/CxxQt.cmake
@@ -136,7 +136,7 @@ function(cxx_qt_import_qml_module target)
     DEPENDS ${QML_MODULE_SOURCE_CRATE}
     BYPRODUCTS "${QML_MODULE_DIR}/plugin_init.o")
 
-  add_library(${target} OBJECT IMPORTED)
+  add_library(${target} OBJECT IMPORTED GLOBAL)
   set_target_properties(${target}
     PROPERTIES
     IMPORTED_OBJECTS "${QML_MODULE_DIR}/plugin_init.o")


### PR DESCRIPTION
As per the CMake documentation, by default IMPORTED targets are only
visible within the current directory.
This isn't useful behavior in our case, so make it globally accessible.

See also: https://cmake.org/cmake/help/latest/command/add_library.html#imported-libraries
