### PR TITLE
Fix: Update Corrosion to 0.5.1 to fix build with Rustup 1.28.0

### DIFF
--- a/cmake/CxxQt.cmake
+++ b/cmake/CxxQt.cmake
@@ -12,7 +12,7 @@ if(NOT Corrosion_FOUND)
     FetchContent_Declare(
         Corrosion
         GIT_REPOSITORY https://github.com/corrosion-rs/corrosion.git
-        GIT_TAG v0.5.0
+        GIT_TAG v0.5.1
     )
 
     FetchContent_MakeAvailable(Corrosion)


### PR DESCRIPTION
This new Rustup release changes how toolchains are installed, fortunately there's a new Corrosion release to handle this.