### PR TITLE
0.7 backports

### DIFF
--- a/cmake/CxxQt.cmake
+++ b/cmake/CxxQt.cmake
@@ -61,6 +61,16 @@ function(cxx_qt_import_crate)
       "QMAKE=${IMPORT_CRATE_QMAKE}"
       $<$<BOOL:${CMAKE_RUSTC_WRAPPER}>:RUSTC_WRAPPER=${CMAKE_RUSTC_WRAPPER}>)
 
+    # When using WASM ensure that we have RUST_CXX_NO_EXCEPTIONS set
+    if (${CMAKE_SYSTEM_NAME} MATCHES "Emscripten")
+        # Read any existing CXX_FLAGS and append RUST_CXX_NO_EXCEPTIONS
+        set(EMSCRIPTEN_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+        list(APPEND EMSCRIPTEN_CXX_FLAGS "-DRUST_CXX_NO_EXCEPTIONS")
+
+        message(STATUS "CXX-Qt Found Emscripten, setting CXXFLAGS=${EMSCRIPTEN_CXX_FLAGS}")
+        corrosion_set_env_vars(${CRATE} "CXXFLAGS=${EMSCRIPTEN_CXX_FLAGS}")
+    endif()
+
     file(MAKE_DIRECTORY "${IMPORT_CRATE_CXX_QT_EXPORT_DIR}/crates/${CRATE}/include/")
     target_include_directories(${CRATE} INTERFACE "${IMPORT_CRATE_CXX_QT_EXPORT_DIR}/crates/${CRATE}/include/")
 

--- a/cmake/CxxQt.cmake
+++ b/cmake/CxxQt.cmake
@@ -12,7 +12,7 @@ if(NOT Corrosion_FOUND)
     FetchContent_Declare(
         Corrosion
         GIT_REPOSITORY https://github.com/corrosion-rs/corrosion.git
-        GIT_TAG v0.5.0
+        GIT_TAG v0.5.1
     )
 
     FetchContent_MakeAvailable(Corrosion)

--- a/cmake/CxxQt.cmake
+++ b/cmake/CxxQt.cmake
@@ -136,7 +136,7 @@ function(cxx_qt_import_qml_module target)
     DEPENDS ${QML_MODULE_SOURCE_CRATE}
     BYPRODUCTS "${QML_MODULE_DIR}/plugin_init.o")
 
-  add_library(${target} OBJECT IMPORTED)
+  add_library(${target} OBJECT IMPORTED GLOBAL)
   set_target_properties(${target}
     PROPERTIES
     IMPORTED_OBJECTS "${QML_MODULE_DIR}/plugin_init.o")


### PR DESCRIPTION
- **Fix: Make qml module targets publicly visible**
- **cmake: set RUST_CXX_NO_EXCEPTIONS when building for emscripten**
- **Warn if MSVC Debug build uses wrong runtime**
- **Fix: Update Corrosion to 0.5.1 to fix build with Rustup 1.28.0**
