### PR TITLE
0.7.2 backports

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 
 cmake_minimum_required(VERSION 3.22)
 project(CxxQt
-    VERSION 0.7.1
+    VERSION 0.7.2
     LANGUAGES NONE
     HOMEPAGE_URL "https://github.com/kdab/cxx-qt/"
 )

--- a/cmake/CxxQt.cmake
+++ b/cmake/CxxQt.cmake
@@ -6,13 +6,13 @@
 
 option(CXX_QT_SUPPRESS_MSVC_RUNTIME_WARNING "Disable checking that the CMAKE_MSVC_RUNTIME_LIBRARY is set when importing Cargo targets in Debug builds with MSVC.")
 
-find_package(Corrosion 0.5.1 QUIET)
+find_package(Corrosion 0.5.2 QUIET)
 if(NOT Corrosion_FOUND)
     include(FetchContent)
     FetchContent_Declare(
         Corrosion
         GIT_REPOSITORY https://github.com/corrosion-rs/corrosion.git
-        GIT_TAG v0.5.1
+        GIT_TAG v0.5.2
     )
 
     FetchContent_MakeAvailable(Corrosion)

--- a/cmake/CxxQt.cmake
+++ b/cmake/CxxQt.cmake
@@ -6,7 +6,7 @@
 
 option(CXX_QT_SUPPRESS_MSVC_RUNTIME_WARNING "Disable checking that the CMAKE_MSVC_RUNTIME_LIBRARY is set when importing Cargo targets in Debug builds with MSVC.")
 
-find_package(Corrosion QUIET)
+find_package(Corrosion 0.5.1 QUIET)
 if(NOT Corrosion_FOUND)
     include(FetchContent)
     FetchContent_Declare(


### PR DESCRIPTION
The following PRs are included:

- #13
- #11
- #14

Note: #12 is not included, as it was reverted by #13.

Additional commits:

- **Bump version to 0.7.2**
