### PR TITLE
Setup support for dynamic QML plugins

### DIFF
--- a/cmake/CxxQt.cmake
+++ b/cmake/CxxQt.cmake
@@ -127,36 +127,41 @@ function(cxx_qt_import_crate)
       PROPERTIES
       CXX_QT_EXPORT_DIR "${IMPORT_CRATE_CXX_QT_EXPORT_DIR}")
 
-    # cxx-qt-build generates object files that need to be linked to the final target.
-    # These are the static initializers that would be removed as an optimization if they're not referenced.
-    # So add them to an object library instead.
-    file(MAKE_DIRECTORY "${IMPORT_CRATE_CXX_QT_EXPORT_DIR}/crates/${CRATE}/")
-    # When using the Ninja generator, we need to provide **some** way to generate the object file
-    # Unfortunately I'm not able to tell corrosion that this obj file is indeed a byproduct, so
-    # create a fake target for it.
-    # This target doesn't need to do anything, because the file should already exist after building the crate.
-    add_custom_target(${CRATE}_mock_initializers
-      COMMAND ${CMAKE_COMMAND} -E true
-      DEPENDS ${CRATE}
-      BYPRODUCTS "${IMPORT_CRATE_CXX_QT_EXPORT_DIR}/crates/${CRATE}/initializers.o")
+    # If the crate is a static library, link it to the required object files to ensure the CMake linker invocations
+    # includes the static initializers.
+    # This is not necessary for dynamic libraries, as they are linked with Cargo.
+    if(TARGET ${CRATE}-static)
+      # cxx-qt-build generates object files that need to be linked to the final target.
+      # These are the static initializers that would be removed as an optimization if they're not referenced.
+      # So add them to an object library instead.
+      file(MAKE_DIRECTORY "${IMPORT_CRATE_CXX_QT_EXPORT_DIR}/crates/${CRATE}/")
+      # When using the Ninja generator, we need to provide **some** way to generate the object file
+      # Unfortunately I'm not able to tell corrosion that this obj file is indeed a byproduct, so
+      # create a fake target for it.
+      # This target doesn't need to do anything, because the file should already exist after building the crate.
+      add_custom_target(${CRATE}_mock_initializers
+        COMMAND ${CMAKE_COMMAND} -E true
+        DEPENDS ${CRATE}
+        BYPRODUCTS "${IMPORT_CRATE_CXX_QT_EXPORT_DIR}/crates/${CRATE}/initializers.o")
 
-    add_library(${CRATE}_initializers OBJECT IMPORTED)
-    set_target_properties(${CRATE}_initializers
-      PROPERTIES
-      IMPORTED_OBJECTS "${IMPORT_CRATE_CXX_QT_EXPORT_DIR}/crates/${CRATE}/initializers.o")
-    # Note that we need to link using TARGET_OBJECTS, so that the object files are included **transitively**, otherwise
-    # Only the linker flags from the object library would be included, but not the actual object files.
-    # See also the "Linking Object Libraries" and "Linking Object Libraries via $<TARGET_OBJECTS>" sections:
-    # https://cmake.org/cmake/help/latest/command/target_link_libraries.html
-    target_link_libraries(${CRATE} INTERFACE ${CRATE}_initializers $<TARGET_OBJECTS:${CRATE}_initializers>)
+      add_library(${CRATE}_initializers OBJECT IMPORTED)
+      set_target_properties(${CRATE}_initializers
+        PROPERTIES
+        IMPORTED_OBJECTS "${IMPORT_CRATE_CXX_QT_EXPORT_DIR}/crates/${CRATE}/initializers.o")
+      # Note that we need to link using TARGET_OBJECTS, so that the object files are included **transitively**, otherwise
+      # Only the linker flags from the object library would be included, but not the actual object files.
+      # See also the "Linking Object Libraries" and "Linking Object Libraries via $<TARGET_OBJECTS>" sections:
+      # https://cmake.org/cmake/help/latest/command/target_link_libraries.html
+      target_link_libraries(${CRATE} INTERFACE ${CRATE}_initializers $<TARGET_OBJECTS:${CRATE}_initializers>)
 
-    # Link the static library to Qt
-    # Note that we cannot do this on the final CRATE target as this is an interface
-    # which depends on the static library. If we do target_link_libraries on the ${CRATE} target,
-    # the static library will not actually depend on the Qt modules, but be a kind of "sibling dependency", which CMake may reorder.
-    # This can cause CMake to emit the wrong link order, with Qt before the static library, which then fails to build with ld.bfd
-    # https://stackoverflow.com/questions/51333069/how-do-the-library-selection-rules-differ-between-gold-and-the-standard-bfd-li
-    target_link_libraries(${CRATE}-static INTERFACE ${IMPORT_CRATE_QT_MODULES})
+      # Link the static library to Qt
+      # Note that we cannot do this on the final CRATE target as this is an interface
+      # which depends on the static library. If we do target_link_libraries on the ${CRATE} target,
+      # the static library will not actually depend on the Qt modules, but be a kind of "sibling dependency", which CMake may reorder.
+      # This can cause CMake to emit the wrong link order, with Qt before the static library, which then fails to build with ld.bfd
+      # https://stackoverflow.com/questions/51333069/how-do-the-library-selection-rules-differ-between-gold-and-the-standard-bfd-li
+      target_link_libraries(${CRATE}-static INTERFACE ${IMPORT_CRATE_QT_MODULES})
+    endif()
   endforeach()
 
 endfunction()


### PR DESCRIPTION
Supporting dynamic QML plugins means mostly copying the dynamic library and qmldir files to the right locations.
This patch makes cxx_qt_add_qml_module set this up automatically, if the Rust crate is built to a dynamic library.